### PR TITLE
5 combine slow and fast methods

### DIFF
--- a/BiG/bispectrumExtractor.py
+++ b/BiG/bispectrumExtractor.py
@@ -9,7 +9,7 @@ from jax import config
 config.update('jax_enable_x64', True)
 
 class bispectrumExtractor:
-    def __init__(self, L, Nmesh, kbinedges, verbose=True) -> None:
+    def __init__(self, L, Nmesh, kbinedges, verbose=True, low_mem=True) -> None:
         """Initializer of bispectrumExtractor
         Also calculates mesh of k-vectors
 
@@ -27,6 +27,7 @@ class bispectrumExtractor:
         self.prefactor=self.L**6/self.Nmesh**9 #Prefactor for bispectrum 
         # For n-point correlations, the prefactor needs to be L^(n-1)/N^(3*n)
         self.verbose=verbose
+        self.low_mem=low_mem
 
         if self.verbose:
             print("Finished setting members of bispectrumExtractor")
@@ -143,242 +144,313 @@ class bispectrumExtractor:
         Iks=device_put(Iks, devices("cpu")[0])
         return Iks
     
-    def calculateBispectrumNormalization(self, mode='equilateral'):
-        """Calculates the Bispectrum Normalization. Only needs to be run once for all simulations with the same L and Nmesh
+    def calculateBispectrumNormalization(self, mode='equilateral', custom_kbinedges_low=[], custom_kbinedges_high=[], precision=np.float64):
+        """Calculates the Bispectrum Normalization. Only needs to be run once for all simulations with the same L and Nmesh.
 
         Args:
-            mode (str, optional): Which k-triangles to consider. Can be 'equilateral' or 'all'. Defaults to 'equilateral'.
-
-        Warning:
-            This algorithm requires a lot of memory, in particular if we look at many k-bins! 
-            Should be the same speed as calculateBispectrumNormalization_slow for equilateral triangles, but significantly faster for all triangles!
+            mode (str, optional): Which k-triangles to consider. Can be 'equilateral', 'custom', or 'all'. Defaults to 'equilateral'.
 
         Returns:
-            list: normalizations for each triangle configuration
+            list: normalizations for each triangle configuration.
         """
-        Norms=self.calculateNorms()
-        normalization=[]
-        if mode=='equilateral':
+        normalization = []
+
+        if self.low_mem:
+            Ones = jnp.ones((self.Nmesh, self.Nmesh, self.Nmesh), dtype=precision)
+        else:
+            Norms = self.calculateNorms()
+
+        if mode in {'equilateral', 'all'}:
             for i in range(self.Nks):
-               
-                tmp=jnp.sum(Norms[:,:,:,i]**3)
-                normalization.append(tmp)
-        elif mode=='all':
-            for i in range(self.Nks):
+                Norm1 = (self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i]) if  self.low_mem else Norms[:,:,:,i] )
+                
+                if mode == 'equilateral':
+                    normalization.append(jnp.sum(Norm1**3))
+                    continue
+
                 for j in range(i, self.Nks):
+                    Norm2 = Norm1 if i == j else ( self.calculateIk(Ones, self.kbinedges[0][j], self.kbinedges[1][j]) if self.low_mem else Norms[:,:,:,j] )
+
                     for k in range(j, self.Nks):
-                        if self.kbinedges[2][k]<self.kbinedges[2][i]+self.kbinedges[2][j]:
-                            tmp=jnp.sum(Norms[:,:,:,i]*Norms[:,:,:,j]*Norms[:,:,:,k])
-                            normalization.append(tmp)
-        
+                        if self.kbinedges[2][k] > self.kbinedges[2][i] + self.kbinedges[2][j]:
+                            continue
+
+                        Norm3 = Norm1 if k == i else (Norm2 if k == j else (self.calculateIk(Ones, self.kbinedges[0][k], self.kbinedges[1][k])) if self.low_mem else  Norms[:,:,:,k])
+
+                        normalization.append(jnp.sum(Norm1 * Norm2 * Norm3))
+
+        elif mode == 'custom':
+            if not custom_kbinedges_low or not custom_kbinedges_high:
+                raise ValueError(f"custom_kbinedges need to be provided if mode is {mode}")
+            if self.low_mem and self.verbose:
+                print("Warning: Using low-memory mode with custom bin edges; high-memory optimization not applicable.")
+            for low, high in zip(custom_kbinedges_low, custom_kbinedges_high):
+                Norm1, Norm2, Norm3 = [self.calculateIk(Ones, low[i], high[i]) for i in range(3)]
+                normalization.append(jnp.sum(Norm1 * Norm2 * Norm3))
+
+        else:
+            raise ValueError(f"Mode cannot be {mode}, must be either 'all', 'equilateral', or 'custom'.")
+
         return normalization
 
-    def calculateEffectiveTriangle(self, mode='equilateral'):
-        """Calculates the Effective Triangles. Only needs to be run once for all simulations with the same L and Nmesh
+    def calculateEffectiveTriangle(self, mode='equilateral', custom_kbinedges_low=[], custom_kbinedges_high=[], precision=np.float64):
+        """Calculates the Effective Triangles. Only needs to be run once for all simulations with the same L and Nmesh.
 
         Args:
-            mode (str, optional): Which k-triangles to consider. Can be 'equilateral' or 'all'. Defaults to 'equilateral'.
+            mode (str, optional): Which k-triangles to consider. Can be 'equilateral', 'all', or 'custom'. Defaults to 'equilateral'.
 
-        Warning:
-            This algorithm requires a lot of memory, in particular if we look at many k-bins! 
-            Should be the same speed as calculateEffectiveTriangle_slow for equilateral triangles, but significantly faster for all triangles!
-            The effective triangles are not normalized! Need to be divided by output of calculateBispectrumNormalization!
 
         Returns:
-            list: effective triangle configurations
+            list: Effective triangle configurations.
         """
-        Norms=self.calculateNorms()
-        Ik_Qs=self.calculateIk_Q()
-        effectiveKs=[]
-        if mode=='equilateral':
-            for i in range(self.Nks):
-               
-                k=jnp.sum(Norms[:,:,:,i]**2*Ik_Qs[:,:,:,i])
-                effectiveKs.append([k,k,k])
-        elif mode=='all':
-            for i in range(self.Nks):
-                for j in range(i, self.Nks):
-                    for k in range(j, self.Nks):
-                        if self.kbinedges[2][k]<self.kbinedges[2][i]+self.kbinedges[2][j]:
-                            k1=jnp.sum(Ik_Qs[:,:,:,i]*Norms[:,:,:,j]*Norms[:,:,:,k])
-                            k2=jnp.sum(Norms[:,:,:,i]*Ik_Qs[:,:,:,j]*Norms[:,:,:,k])
-                            k3=jnp.sum(Norms[:,:,:,i]*Norms[:,:,:,j]*Ik_Qs[:,:,:,k])
-
-                            effectiveKs.append([k1,k2,k3])
         
+        effectiveKs = []
+        Ones = None if not self.low_mem else jnp.ones((self.Nmesh, self.Nmesh, self.Nmesh), dtype=precision)
+        Norms = None if self.low_mem else self.calculateNorms()
+        Ik_Qs = None if self.low_mem else self.calculateIk_Q()
+
+        if mode in {'equilateral', 'all'}:
+            for i in range(self.Nks):
+                Norm1 = self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i]) if self.low_mem else Norms[:,:,:,i]
+                Ik_Q1 = self.calculateIk(self.kmesh, self.kbinedges[0][i], self.kbinedges[1][i]) if self.low_mem else Ik_Qs[:,:,:,i]
+
+                if mode == 'equilateral':
+                    k = jnp.sum(Norm1**2 * Ik_Q1)
+                    effectiveKs.append([k, k, k])
+                    continue
+
+                for j in range(i, self.Nks):
+                    Norm2 = Norm1 if i == j else (self.calculateIk(Ones, self.kbinedges[0][j], self.kbinedges[1][j]) if self.low_mem else Norms[:,:,:,j])
+                    Ik_Q2 = Ik_Q1 if i == j else (self.calculateIk(self.kmesh, self.kbinedges[0][j], self.kbinedges[1][j]) if self.low_mem else Ik_Qs[:,:,:,j])
+
+                    for k in range(j, self.Nks):
+                        if self.kbinedges[2][k] > self.kbinedges[2][i] + self.kbinedges[2][j]:
+                            continue
+
+                        Norm3 = Norm1 if k == i else (Norm2 if k == j else (self.calculateIk(Ones, self.kbinedges[0][k], self.kbinedges[1][k]) if self.low_mem else Norms[:,:,:,k]))
+                        Ik_Q3 = Ik_Q1 if k == i else (Ik_Q2 if k == j else (self.calculateIk(self.kmesh, self.kbinedges[0][k], self.kbinedges[1][k]) if self.low_mem else Ik_Qs[:,:,:,k]))
+
+                        effectiveKs.append([
+                            jnp.sum(Ik_Q1 * Norm2 * Norm3),
+                            jnp.sum(Norm1 * Ik_Q2 * Norm3),
+                            jnp.sum(Norm1 * Norm2 * Ik_Q3)
+                        ])
+
+        elif mode == 'custom':
+            if not custom_kbinedges_low or not custom_kbinedges_high:
+                raise ValueError(f"custom_kbinedges need to be provided if mode is {mode}")
+            if self.low_mem and self.verbose:
+                print("Warning: Using low-memory mode with custom bin edges; high-memory optimization not applicable.")
+            for low, high in zip(custom_kbinedges_low, custom_kbinedges_high):
+                Norm2, Norm3 = [self.calculateIk(Ones, low[i], high[i]) for i in (1, 2)]
+                Ik_Q1 = self.calculateIk(self.kmesh, low[0], high[0])
+                k1 = jnp.sum(Ik_Q1 * Norm2 * Norm3)
+
+                Norm1 = self.calculateIk(Ones, low[0], high[0])
+                Ik_Q2 = self.calculateIk(self.kmesh, low[1], high[1])
+                k2 = jnp.sum(Norm1 * Ik_Q2 * Norm3)
+
+                Ik_Q3 = self.calculateIk(self.kmesh, low[2], high[2])
+                k3 = jnp.sum(Norm1 * Norm2 * Ik_Q3)
+
+                effectiveKs.append([k1, k2, k3])
+
+        else:
+            raise ValueError(f"Mode cannot be {mode}, must be 'all', 'equilateral', or 'custom'.")
+
         return effectiveKs
 
 
 
-    def calculateBispectrum(self, field_real, mode='equilateral'):
-        """Calculates the unnormalized Bispectrum with the faster (but more memory intensive) algorithm
+
+    def calculateBispectrum(self, field_real, mode='equilateral', custom_kbinedges_low=[], custom_kbinedges_high=[]):
+        """Calculates the unnormalized Bispectrum using either the low-memory or high-memory code.
 
         Args:
-            field_real (np.ndarray): Real space density field (in numpy binary format)
-            mode (str, optional): Which k-triangles to consider. Can be 'equilateral' or 'all'. Defaults to 'equilateral'.
-
-        Warning:
-            This algorithm requires a lot of memory, in particular if we look at many k-bins! 
-            Should be the same speed as calculateBispectrumNormalization_slow for equilateral triangles, but significantly faster for all triangles!
+            field_real (np.ndarray): Real space density field (in numpy binary format).
+            mode (str, optional): Which k-triangles to consider. Can be 'equilateral', 'all', 'custom'. Defaults to 'equilateral'.
 
         Returns:
-            list: unnormalized bispectrum for each triangle configuration
+            list: Unnormalized bispectrum for each triangle configuration.
         """
-        field_fourier=self.getFourierField(field_real)
         
-        Iks=self.calculateIks(field_fourier)
-
-        bispec=[]
-        if mode=='equilateral':
-            for i in range(self.Nks):
-                Ik=Iks[:,:,:,i]
-                print(Ik[Ik!=0].shape)
-                
-                tmp=jnp.sum(Iks[:,:,:,i]**3)
-                bispec.append(tmp)
-        elif mode=='all':
-            for i in range(self.Nks):
-                for j in range(i, self.Nks):
-                    for k in range(j, self.Nks):
-                        if self.kbinedges[2][k]<self.kbinedges[2][i]+self.kbinedges[2][j]:
-                            tmp=jnp.sum(Iks[:,:,:,i]*Iks[:,:,:,j]*Iks[:,:,:,k])
-                            bispec.append(tmp)
-        else:
-            raise ValueError(f"Mode cannot be {mode}, has to be either 'all' or 'equilateral'")
-        
-        return bispec
-        
-
-    def calculateBispectrum_slow(self, field_real, mode='equilateral', custom_kbinedges_low=[], custom_kbinedges_high=[]):
-        """Calculates the unnormalized Bispectrum with the slower (but less memory intensive) algortihm
-
-        Args:
-            field_real (np.ndarray): Real space density field (in numpy binary format)
-            mode (str, optional): Which k-triangles to consider. Can be 'equilateral', 'all' or 'custom'. Defaults to 'equilateral'. If 'custom': bin-edges of k need to be provided
-
-
-        Warning:
-            This algorithm should be the same speed as calculateBispectrum for equilateral triangles, but significantly slower for all triangles!
-
-        Returns:
-            list: unnormalized bispectrum for each triangle configuration
-        """
-
         if self.verbose:
             print("Doing Fourier Transformation of density field")
-
-        field_fourier=self.getFourierField(field_real)
+        field_fourier = self.getFourierField(field_real)
 
         if self.verbose:
             print("Doing Bispec calculation")
-        bispec=[]
-        if mode=='equilateral':
+
+        bispec = []
+        Iks = None if self.low_mem else self.calculateIks(field_fourier)  # Precompute all Iks if not low_mem
+
+        if mode in {'equilateral', 'all'}:
             for i in range(self.Nks):
-                Ik=self.calculateIk(field_fourier, self.kbinedges[0][i], self.kbinedges[1][i])
-                tmp=jnp.sum(Ik**3)
-                bispec.append(tmp)
-        elif mode=='all':
-            for i in range(self.Nks):
-                Ik1=self.calculateIk(field_fourier, self.kbinedges[0][i], self.kbinedges[1][i])
+                Ik1 = self.calculateIk(field_fourier, self.kbinedges[0][i], self.kbinedges[1][i]) if self.low_mem else Iks[:,:,:,i]
+
+                if mode == 'equilateral':
+                    bispec.append(jnp.sum(Ik1**3))
+                    continue
+
                 for j in range(i, self.Nks):
-                    if(i==j):
-                        Ik2=Ik1
-                    else:
-                        Ik2=self.calculateIk(field_fourier, self.kbinedges[0][j], self.kbinedges[1][j])
+                    Ik2 = Ik1 if i == j else (self.calculateIk(field_fourier, self.kbinedges[0][j], self.kbinedges[1][j]) if self.low_mem else Iks[:,:,:,j])
+
                     for k in range(j, self.Nks):
-                        if self.kbinedges[2][k]<=self.kbinedges[2][i]+self.kbinedges[2][j]:
-                            if (k==i):
-                                Ik3=Ik1
-                            elif (k==j):
-                                Ik3=Ik2
-                            else:
-                                Ik3=self.calculateIk(field_fourier, self.kbinedges[0][k], self.kbinedges[1][k])
-                            tmp=jnp.sum(Ik1*Ik2*Ik3)
-                            del Ik3
-                            bispec.append(tmp)
-        elif mode=='custom':
-            if (len(custom_kbinedges_low)==0) or (len(custom_kbinedges_high)==0):
+                        if self.kbinedges[2][k] > self.kbinedges[2][i] + self.kbinedges[2][j]:
+                            continue
+
+                        Ik3 = Ik1 if k == i else (Ik2 if k == j else (self.calculateIk(field_fourier, self.kbinedges[0][k], self.kbinedges[1][k]) if self.low_mem else Iks[:,:,:,k]))
+
+                        bispec.append(jnp.sum(Ik1 * Ik2 * Ik3))
+
+        elif mode == 'custom':
+            if not custom_kbinedges_low or not custom_kbinedges_high:
                 raise ValueError(f"custom_kbinedges need to be provided if mode is {mode}")
-            for i in range(len(custom_kbinedges_low)):
-                Ik1=self.calculateIk(field_fourier, custom_kbinedges_low[i][0], custom_kbinedges_high[i][0])
-                Ik2=self.calculateIk(field_fourier, custom_kbinedges_low[i][1], custom_kbinedges_high[i][1])
-                Ik3=self.calculateIk(field_fourier, custom_kbinedges_low[i][2], custom_kbinedges_high[i][2])
 
-                tmp=jnp.sum(Ik1*Ik2*Ik3)
-                del Ik1
-                del Ik2
-                del Ik3
+            if self.low_mem and self.verbose:
+                print("Warning: Using low-memory mode with custom bin edges; high-memory optimization not applicable.")
 
-                bispec.append(tmp)
+            for low, high in zip(custom_kbinedges_low, custom_kbinedges_high):
+                Ik1, Ik2, Ik3 = [self.calculateIk(field_fourier, low[i], high[i]) for i in range(3)]
+                bispec.append(jnp.sum(Ik1 * Ik2 * Ik3))
+
         else:
-            raise ValueError(f"Mode cannot be {mode}, has to be either 'all', 'equilateral' or 'custom'")
-        
+            raise ValueError(f"Mode cannot be {mode}, must be either 'all', 'equilateral', or 'custom'.")
+
         return bispec
+
+        
+
+    # def calculateBispectrum_slow(self, field_real, mode='equilateral', custom_kbinedges_low=[], custom_kbinedges_high=[]):
+    #     """Calculates the unnormalized Bispectrum with the slower (but less memory intensive) algortihm
+
+    #     Args:
+    #         field_real (np.ndarray): Real space density field (in numpy binary format)
+    #         mode (str, optional): Which k-triangles to consider. Can be 'equilateral', 'all' or 'custom'. Defaults to 'equilateral'. If 'custom': bin-edges of k need to be provided
+
+
+    #     Warning:
+    #         This algorithm should be the same speed as calculateBispectrum for equilateral triangles, but significantly slower for all triangles!
+
+    #     Returns:
+    #         list: unnormalized bispectrum for each triangle configuration
+    #     """
+
+    #     if self.verbose:
+    #         print("Doing Fourier Transformation of density field")
+
+    #     field_fourier=self.getFourierField(field_real)
+
+    #     if self.verbose:
+    #         print("Doing Bispec calculation")
+    #     bispec=[]
+    #     if mode=='equilateral':
+    #         for i in range(self.Nks):
+    #             Ik=self.calculateIk(field_fourier, self.kbinedges[0][i], self.kbinedges[1][i])
+    #             tmp=jnp.sum(Ik**3)
+    #             bispec.append(tmp)
+    #     elif mode=='all':
+    #         for i in range(self.Nks):
+    #             Ik1=self.calculateIk(field_fourier, self.kbinedges[0][i], self.kbinedges[1][i])
+    #             for j in range(i, self.Nks):
+    #                 if(i==j):
+    #                     Ik2=Ik1
+    #                 else:
+    #                     Ik2=self.calculateIk(field_fourier, self.kbinedges[0][j], self.kbinedges[1][j])
+    #                 for k in range(j, self.Nks):
+    #                     if self.kbinedges[2][k]<=self.kbinedges[2][i]+self.kbinedges[2][j]:
+    #                         if (k==i):
+    #                             Ik3=Ik1
+    #                         elif (k==j):
+    #                             Ik3=Ik2
+    #                         else:
+    #                             Ik3=self.calculateIk(field_fourier, self.kbinedges[0][k], self.kbinedges[1][k])
+    #                         tmp=jnp.sum(Ik1*Ik2*Ik3)
+    #                         del Ik3
+    #                         bispec.append(tmp)
+    #     elif mode=='custom':
+    #         if (len(custom_kbinedges_low)==0) or (len(custom_kbinedges_high)==0):
+    #             raise ValueError(f"custom_kbinedges need to be provided if mode is {mode}")
+    #         for i in range(len(custom_kbinedges_low)):
+    #             Ik1=self.calculateIk(field_fourier, custom_kbinedges_low[i][0], custom_kbinedges_high[i][0])
+    #             Ik2=self.calculateIk(field_fourier, custom_kbinedges_low[i][1], custom_kbinedges_high[i][1])
+    #             Ik3=self.calculateIk(field_fourier, custom_kbinedges_low[i][2], custom_kbinedges_high[i][2])
+
+    #             tmp=jnp.sum(Ik1*Ik2*Ik3)
+    #             del Ik1
+    #             del Ik2
+    #             del Ik3
+
+    #             bispec.append(tmp)
+    #     else:
+    #         raise ValueError(f"Mode cannot be {mode}, has to be either 'all', 'equilateral' or 'custom'")
+        
+    #     return bispec
     
 
 
-    def calculateBispectrumNormalization_slow(self, mode='equilateral', custom_kbinedges_low=[], custom_kbinedges_high=[], precision=np.float64):
-        """Calculates the normalization with the slower (but less memory intensive) algortihm. Only needs to be run once for all simulations with the same L and Nmesh
+    # def calculateBispectrumNormalization_slow(self, mode='equilateral', custom_kbinedges_low=[], custom_kbinedges_high=[], precision=np.float64):
+    #     """Calculates the normalization with the slower (but less memory intensive) algortihm. Only needs to be run once for all simulations with the same L and Nmesh
 
-        Args:
-            mode (str, optional): Which k-triangles to consider. Can be 'equilateral', 'all' or 'custom'. Defaults to 'equilateral'. If 'custom': bin-edges of k need to be provided
+    #     Args:
+    #         mode (str, optional): Which k-triangles to consider. Can be 'equilateral', 'all' or 'custom'. Defaults to 'equilateral'. If 'custom': bin-edges of k need to be provided
 
-        Warning:
-           This algorithm should be the same speed as calculateBispectrumNormalization for equilateral triangles, but significantly slower for all triangles!
+    #     Warning:
+    #        This algorithm should be the same speed as calculateBispectrumNormalization for equilateral triangles, but significantly slower for all triangles!
 
-        Returns:
-            list: unnormalized bispectrum for each triangle configuration
-        """
-        Ones=jnp.ones((self.Nmesh, self.Nmesh, self.Nmesh), dtype=precision)
+    #     Returns:
+    #         list: unnormalized bispectrum for each triangle configuration
+    #     """
+    #     Ones=jnp.ones((self.Nmesh, self.Nmesh, self.Nmesh), dtype=precision)
 
-        normalization=[]
-        if mode=='equilateral':
-            for i in range(self.Nks):
-                Norm=self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i])
-                tmp=jnp.sum(Norm**3)
-                normalization.append(tmp)
-        elif mode=='all':
-            for i in range(self.Nks):
-                Norm1=self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i])
-
-
-                for j in range(i, self.Nks):
-                    if i==j:
-                        Norm2=Norm1
-                    else:
-                        Norm2=self.calculateIk(Ones, self.kbinedges[0][j], self.kbinedges[1][j])
-
-                    for k in range(j, self.Nks):
-                        if self.kbinedges[2][k]<=self.kbinedges[2][i]+self.kbinedges[2][j]:
-                            if k==i:
-                                Norm3=Norm1
-                            elif k==j:
-                                Norm3=Norm2
-                            else:
-                                Norm3=self.calculateIk(Ones, self.kbinedges[0][k], self.kbinedges[1][k])
-                            tmp=jnp.sum(Norm1*Norm2*Norm3)
-                            del Norm3
-                            normalization.append(tmp)
-                    del Norm2
-        elif mode=='custom':
-            if (len(custom_kbinedges_low)==0) or (len(custom_kbinedges_high)==0):
-                raise ValueError(f"custom_kbinedges need to be provided if mode is {mode}")
-            for i in range(len(custom_kbinedges_low)):
-                Norm1=self.calculateIk(Ones, custom_kbinedges_low[i][0], custom_kbinedges_high[i][0])
-                Norm2=self.calculateIk(Ones, custom_kbinedges_low[i][1], custom_kbinedges_high[i][1])
-                Norm3=self.calculateIk(Ones, custom_kbinedges_low[i][2], custom_kbinedges_high[i][2])
-
-                tmp=jnp.sum(Norm1*Norm2*Norm3)
-                del Norm1
-                del Norm2
-                del Norm3
-                normalization.append(tmp)
+    #     normalization=[]
+    #     if mode=='equilateral':
+    #         for i in range(self.Nks):
+    #             Norm=self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i])
+    #             tmp=jnp.sum(Norm**3)
+    #             normalization.append(tmp)
+    #     elif mode=='all':
+    #         for i in range(self.Nks):
+    #             Norm1=self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i])
 
 
-        else:
-            raise ValueError(f"Mode cannot be {mode}, has to be either 'all','equilateral' or 'custom'")
+    #             for j in range(i, self.Nks):
+    #                 if i==j:
+    #                     Norm2=Norm1
+    #                 else:
+    #                     Norm2=self.calculateIk(Ones, self.kbinedges[0][j], self.kbinedges[1][j])
+
+    #                 for k in range(j, self.Nks):
+    #                     if self.kbinedges[2][k]<=self.kbinedges[2][i]+self.kbinedges[2][j]:
+    #                         if k==i:
+    #                             Norm3=Norm1
+    #                         elif k==j:
+    #                             Norm3=Norm2
+    #                         else:
+    #                             Norm3=self.calculateIk(Ones, self.kbinedges[0][k], self.kbinedges[1][k])
+    #                         tmp=jnp.sum(Norm1*Norm2*Norm3)
+    #                         del Norm3
+    #                         normalization.append(tmp)
+    #                 del Norm2
+    #     elif mode=='custom':
+    #         if (len(custom_kbinedges_low)==0) or (len(custom_kbinedges_high)==0):
+    #             raise ValueError(f"custom_kbinedges need to be provided if mode is {mode}")
+    #         for i in range(len(custom_kbinedges_low)):
+    #             Norm1=self.calculateIk(Ones, custom_kbinedges_low[i][0], custom_kbinedges_high[i][0])
+    #             Norm2=self.calculateIk(Ones, custom_kbinedges_low[i][1], custom_kbinedges_high[i][1])
+    #             Norm3=self.calculateIk(Ones, custom_kbinedges_low[i][2], custom_kbinedges_high[i][2])
+
+    #             tmp=jnp.sum(Norm1*Norm2*Norm3)
+    #             del Norm1
+    #             del Norm2
+    #             del Norm3
+    #             normalization.append(tmp)
+
+
+    #     else:
+    #         raise ValueError(f"Mode cannot be {mode}, has to be either 'all','equilateral' or 'custom'")
         
-        return normalization
+    #     return normalization
     
 
     def calculateEffectiveTriangle_slow(self, mode='equilateral', custom_kbinedges_low=[], custom_kbinedges_high=[], precision=np.float64):

--- a/BiG/bispectrumExtractor.py
+++ b/BiG/bispectrumExtractor.py
@@ -1,12 +1,14 @@
-
 import numpy as np
-import jax 
-#jax.config.update('jax_platform_name', 'cpu')
+import jax
+
+# jax.config.update('jax_platform_name', 'cpu')
 import jax.numpy as jnp
 from jax import device_put, devices
 from jax import jit
 from jax import config
-config.update('jax_enable_x64', True)
+
+config.update("jax_enable_x64", True)
+
 
 class bispectrumExtractor:
     def __init__(self, L, Nmesh, kbinedges, verbose=True, low_mem=True) -> None:
@@ -18,21 +20,22 @@ class bispectrumExtractor:
             Nmesh (int): Number of Gridcells along one dimension
             kbinedges (np.array): List of k-edges for bispectrum [h/Mpc]
             verbose (bool, optional): Whether to give extra-output to standard output. Defaults to True.
+            low_mem (bool, optional): Whether algorithms with lower memory requirements should be used. Defaults to True.
         """
-        self.L=L
-        self.Nmesh=Nmesh
-        if kbinedges!=[]:
-            self.kbinedges=kbinedges
-            self.Nks=len(kbinedges[0])
-        self.prefactor=self.L**6/self.Nmesh**9 #Prefactor for bispectrum 
+        self.L = L
+        self.Nmesh = Nmesh
+        if kbinedges != []:
+            self.kbinedges = kbinedges
+            self.Nks = len(kbinedges[0])
+        self.prefactor = self.L**6 / self.Nmesh**9  # Prefactor for bispectrum
         # For n-point correlations, the prefactor needs to be L^(n-1)/N^(3*n)
-        self.verbose=verbose
-        self.low_mem=low_mem
+        self.verbose = verbose
+        self.low_mem = low_mem
 
         if self.verbose:
             print("Finished setting members of bispectrumExtractor")
             print("Creating k-mesh")
-        self.kmesh=self.createKmesh()
+        self.kmesh = self.createKmesh()
 
         self.calculateIk = jit(self.calculateIk)
 
@@ -42,13 +45,12 @@ class bispectrumExtractor:
         Returns:
             jnp.array: Jax Numpy array, on device
         """
-        idx, idy, idz= np.indices((self.Nmesh, self.Nmesh, self.Nmesh))
-        idx = idx - idx.shape[0]/2
-        idy = idy - idy.shape[1]/2
-        idz = idz - idz.shape[2]/2
-        return jnp.sqrt(idx**2+idy**2+idz**2)*2*np.pi/self.L
+        idx, idy, idz = np.indices((self.Nmesh, self.Nmesh, self.Nmesh))
+        idx = idx - idx.shape[0] / 2
+        idy = idy - idy.shape[1] / 2
+        idz = idz - idz.shape[2] / 2
+        return jnp.sqrt(idx**2 + idy**2 + idz**2) * 2 * np.pi / self.L
 
-    
     def applyMask(self, field, kmin, kmax):
         """Applies mask to field: If k values are outside of kmin or kmax field is set to zero
 
@@ -62,7 +64,6 @@ class bispectrumExtractor:
         """
         return field * ((self.kmesh <= kmax) & (self.kmesh >= kmin))
 
-
     def getFourierField(self, field_real):
         """Reads out real-space density field and gives back Fourier transformed field
 
@@ -71,9 +72,9 @@ class bispectrumExtractor:
         Returns:
             jnp.ndarray[complex]: Fourier transformed density field
         """
-        
-        dev_field_real=device_put(np.array(field_real, dtype=np.float32))
-        field_fourier=jnp.fft.fftshift(jnp.fft.fftn(dev_field_real))
+
+        dev_field_real = device_put(np.array(field_real, dtype=np.float32))
+        field_fourier = jnp.fft.fftshift(jnp.fft.fftn(dev_field_real))
         del dev_field_real
         return field_fourier
 
@@ -88,13 +89,11 @@ class bispectrumExtractor:
         Returns:
             jnp.ndarray[float]: Ik value for this k bin
         """
-        field_tmp=self.applyMask(field_fourier, kmin, kmax)
+        field_tmp = self.applyMask(field_fourier, kmin, kmax)
 
-        field_tmp=jnp.fft.ifftn(jnp.fft.ifftshift(field_tmp)).real
+        field_tmp = jnp.fft.ifftn(jnp.fft.ifftshift(field_tmp)).real
         return field_tmp
-    
 
-    
     def calculateIks(self, field_fourier):
         """Calculates the Ik for all ks in kbinedges
 
@@ -107,12 +106,14 @@ class bispectrumExtractor:
         Returns:
             np.ndarray: Array containing all Iks (on CPU)
         """
-        Iks=np.zeros((self.Nmesh, self.Nmesh, self.Nmesh, self.Nks), dtype=complex)
+        Iks = np.zeros((self.Nmesh, self.Nmesh, self.Nmesh, self.Nks), dtype=complex)
         for i in range(self.Nks):
-            Iks[:,:,:,i]=self.calculateIk(field_fourier, self.kbinedges[0][i], self.kbinedges[1][i])
-        Iks=device_put(Iks, devices("cpu")[0])
+            Iks[:, :, :, i] = self.calculateIk(
+                field_fourier, self.kbinedges[0][i], self.kbinedges[1][i]
+            )
+        Iks = device_put(Iks, devices("cpu")[0])
         return Iks
-    
+
     def calculateNorms(self):
         """Calculates the bispec normalization for all ks in kbinedges
 
@@ -122,13 +123,15 @@ class bispectrumExtractor:
         Returns:
             np.ndarray: Array containing all Norms (on CPU)
         """
-        Ones=jnp.ones((self.Nmesh, self.Nmesh, self.Nmesh), dtype=float)
-        Norms=np.zeros((self.Nmesh, self.Nmesh, self.Nmesh, self.Nks), dtype=complex)
+        Ones = jnp.ones((self.Nmesh, self.Nmesh, self.Nmesh), dtype=float)
+        Norms = np.zeros((self.Nmesh, self.Nmesh, self.Nmesh, self.Nks), dtype=complex)
         for i in range(self.Nks):
-            Norms[:,:,:,i]=self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i])
-        Norms=device_put(Norms, devices("cpu")[0])
+            Norms[:, :, :, i] = self.calculateIk(
+                Ones, self.kbinedges[0][i], self.kbinedges[1][i]
+            )
+        Norms = device_put(Norms, devices("cpu")[0])
         return Norms
-    
+
     def calculateIk_Q(self):
         """Calculates the Ik integral over the qs for all ks in kbinedges (needed for calculating effective triangles)
 
@@ -138,18 +141,34 @@ class bispectrumExtractor:
         Returns:
             np.ndarray: Array containing all Iks (on CPU)
         """
-        Iks=np.zeros((self.Nmesh, self.Nmesh, self.Nmesh, self.Nks), dtype=np.complex64)
+        Iks = np.zeros(
+            (self.Nmesh, self.Nmesh, self.Nmesh, self.Nks), dtype=np.complex64
+        )
         for i in range(self.Nks):
-            Iks[:,:,:,i]=self.calculateIk(self.kmesh, self.kbinedges[0][i], self.kbinedges[1][i])
-        Iks=device_put(Iks, devices("cpu")[0])
+            Iks[:, :, :, i] = self.calculateIk(
+                self.kmesh, self.kbinedges[0][i], self.kbinedges[1][i]
+            )
+        Iks = device_put(Iks, devices("cpu")[0])
         return Iks
-    
-    def calculateBispectrumNormalization(self, mode='equilateral', custom_kbinedges_low=[], custom_kbinedges_high=[], precision=np.float64):
+
+    def calculateBispectrumNormalization(
+        self,
+        mode="equilateral",
+        custom_kbinedges_low=[],
+        custom_kbinedges_high=[],
+        precision=np.float64,
+    ):
         """Calculates the Bispectrum Normalization. Only needs to be run once for all simulations with the same L and Nmesh.
+
+            If `self.low_mem` is True, the I_ks are calculated on the fly which requires less memory but is slower for unequilateral triangles.
+            Else, the I_ks are calculated once and stored in memory. This should usually be faster, but could run over the RAM.
+            It could also trigger that CPU calculation instead of GPU calculation is performed, which massively decreases the speed.
 
         Args:
             mode (str, optional): Which k-triangles to consider. Can be 'equilateral', 'custom', or 'all'. Defaults to 'equilateral'.
-
+            custom_kbinedges_low (list, optional): lower edge of custom k-bins. Defaults to [].
+            custom_kbinedges_high (list, optional): higher edge of custom k-bins. Defaults to [].
+            precision (dtype, optional): float type of calculation. Defaults to np.float64
         Returns:
             list: normalizations for each triangle configuration.
         """
@@ -160,87 +179,215 @@ class bispectrumExtractor:
         else:
             Norms = self.calculateNorms()
 
-        if mode in {'equilateral', 'all'}:
+        if mode in {"equilateral", "all"}:
             for i in range(self.Nks):
-                Norm1 = (self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i]) if  self.low_mem else Norms[:,:,:,i] )
-                
-                if mode == 'equilateral':
+                Norm1 = (
+                    self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i])
+                    if self.low_mem
+                    else Norms[:, :, :, i]
+                )
+
+                if mode == "equilateral":
                     normalization.append(jnp.sum(Norm1**3))
                     continue
 
                 for j in range(i, self.Nks):
-                    Norm2 = Norm1 if i == j else ( self.calculateIk(Ones, self.kbinedges[0][j], self.kbinedges[1][j]) if self.low_mem else Norms[:,:,:,j] )
+                    Norm2 = (
+                        Norm1
+                        if i == j
+                        else (
+                            self.calculateIk(
+                                Ones, self.kbinedges[0][j], self.kbinedges[1][j]
+                            )
+                            if self.low_mem
+                            else Norms[:, :, :, j]
+                        )
+                    )
 
                     for k in range(j, self.Nks):
-                        if self.kbinedges[2][k] > self.kbinedges[2][i] + self.kbinedges[2][j]:
+                        if (
+                            self.kbinedges[2][k]
+                            > self.kbinedges[2][i] + self.kbinedges[2][j]
+                        ):
                             continue
 
-                        Norm3 = Norm1 if k == i else (Norm2 if k == j else (self.calculateIk(Ones, self.kbinedges[0][k], self.kbinedges[1][k])) if self.low_mem else  Norms[:,:,:,k])
+                        Norm3 = (
+                            Norm1
+                            if k == i
+                            else (
+                                Norm2
+                                if k == j
+                                else (
+                                    (
+                                        self.calculateIk(
+                                            Ones,
+                                            self.kbinedges[0][k],
+                                            self.kbinedges[1][k],
+                                        )
+                                    )
+                                    if self.low_mem
+                                    else Norms[:, :, :, k]
+                                )
+                            )
+                        )
 
                         normalization.append(jnp.sum(Norm1 * Norm2 * Norm3))
 
-        elif mode == 'custom':
+        elif mode == "custom":
             if not custom_kbinedges_low or not custom_kbinedges_high:
-                raise ValueError(f"custom_kbinedges need to be provided if mode is {mode}")
+                raise ValueError(
+                    f"custom_kbinedges need to be provided if mode is {mode}"
+                )
             if self.low_mem and self.verbose:
-                print("Warning: Using low-memory mode with custom bin edges; high-memory optimization not applicable.")
+                print(
+                    "Warning: Using low-memory mode with custom bin edges; high-memory optimization not applicable."
+                )
             for low, high in zip(custom_kbinedges_low, custom_kbinedges_high):
-                Norm1, Norm2, Norm3 = [self.calculateIk(Ones, low[i], high[i]) for i in range(3)]
+                Norm1, Norm2, Norm3 = [
+                    self.calculateIk(Ones, low[i], high[i]) for i in range(3)
+                ]
                 normalization.append(jnp.sum(Norm1 * Norm2 * Norm3))
 
         else:
-            raise ValueError(f"Mode cannot be {mode}, must be either 'all', 'equilateral', or 'custom'.")
+            raise ValueError(
+                f"Mode cannot be {mode}, must be either 'all', 'equilateral', or 'custom'."
+            )
 
         return normalization
 
-    def calculateEffectiveTriangle(self, mode='equilateral', custom_kbinedges_low=[], custom_kbinedges_high=[], precision=np.float64):
+    def calculateEffectiveTriangle(
+        self,
+        mode="equilateral",
+        custom_kbinedges_low=[],
+        custom_kbinedges_high=[],
+        precision=np.float64,
+    ):
         """Calculates the Effective Triangles. Only needs to be run once for all simulations with the same L and Nmesh.
 
-        Args:
-            mode (str, optional): Which k-triangles to consider. Can be 'equilateral', 'all', or 'custom'. Defaults to 'equilateral'.
+        If `self.low_mem` is True, the I_ks are calculated on the fly which requires less memory but is slower for unequilateral triangles.
+        Else, the I_ks are calculated once and stored in memory. This should usually be faster, but could run over the RAM.
+        It could also trigger that CPU calculation instead of GPU calculation is performed, which massively decreases the speed.
 
+        Args:
+            mode (str, optional): Which k-triangles to consider. Can be 'equilateral', 'custom', or 'all'. Defaults to 'equilateral'.
+            custom_kbinedges_low (list, optional): lower edge of custom k-bins. Defaults to [].
+            custom_kbinedges_high (list, optional): higher edge of custom k-bins. Defaults to [].
+            precision (dtype, optional): float type of calculation. Defaults to np.float64
 
         Returns:
             list: Effective triangle configurations.
         """
-        
+
         effectiveKs = []
-        Ones = None if not self.low_mem else jnp.ones((self.Nmesh, self.Nmesh, self.Nmesh), dtype=precision)
+        Ones = (
+            None
+            if not self.low_mem
+            else jnp.ones((self.Nmesh, self.Nmesh, self.Nmesh), dtype=precision)
+        )
         Norms = None if self.low_mem else self.calculateNorms()
         Ik_Qs = None if self.low_mem else self.calculateIk_Q()
 
-        if mode in {'equilateral', 'all'}:
+        if mode in {"equilateral", "all"}:
             for i in range(self.Nks):
-                Norm1 = self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i]) if self.low_mem else Norms[:,:,:,i]
-                Ik_Q1 = self.calculateIk(self.kmesh, self.kbinedges[0][i], self.kbinedges[1][i]) if self.low_mem else Ik_Qs[:,:,:,i]
+                Norm1 = (
+                    self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i])
+                    if self.low_mem
+                    else Norms[:, :, :, i]
+                )
+                Ik_Q1 = (
+                    self.calculateIk(
+                        self.kmesh, self.kbinedges[0][i], self.kbinedges[1][i]
+                    )
+                    if self.low_mem
+                    else Ik_Qs[:, :, :, i]
+                )
 
-                if mode == 'equilateral':
+                if mode == "equilateral":
                     k = jnp.sum(Norm1**2 * Ik_Q1)
                     effectiveKs.append([k, k, k])
                     continue
 
                 for j in range(i, self.Nks):
-                    Norm2 = Norm1 if i == j else (self.calculateIk(Ones, self.kbinedges[0][j], self.kbinedges[1][j]) if self.low_mem else Norms[:,:,:,j])
-                    Ik_Q2 = Ik_Q1 if i == j else (self.calculateIk(self.kmesh, self.kbinedges[0][j], self.kbinedges[1][j]) if self.low_mem else Ik_Qs[:,:,:,j])
+                    Norm2 = (
+                        Norm1
+                        if i == j
+                        else (
+                            self.calculateIk(
+                                Ones, self.kbinedges[0][j], self.kbinedges[1][j]
+                            )
+                            if self.low_mem
+                            else Norms[:, :, :, j]
+                        )
+                    )
+                    Ik_Q2 = (
+                        Ik_Q1
+                        if i == j
+                        else (
+                            self.calculateIk(
+                                self.kmesh, self.kbinedges[0][j], self.kbinedges[1][j]
+                            )
+                            if self.low_mem
+                            else Ik_Qs[:, :, :, j]
+                        )
+                    )
 
                     for k in range(j, self.Nks):
-                        if self.kbinedges[2][k] > self.kbinedges[2][i] + self.kbinedges[2][j]:
+                        if (
+                            self.kbinedges[2][k]
+                            > self.kbinedges[2][i] + self.kbinedges[2][j]
+                        ):
                             continue
 
-                        Norm3 = Norm1 if k == i else (Norm2 if k == j else (self.calculateIk(Ones, self.kbinedges[0][k], self.kbinedges[1][k]) if self.low_mem else Norms[:,:,:,k]))
-                        Ik_Q3 = Ik_Q1 if k == i else (Ik_Q2 if k == j else (self.calculateIk(self.kmesh, self.kbinedges[0][k], self.kbinedges[1][k]) if self.low_mem else Ik_Qs[:,:,:,k]))
+                        Norm3 = (
+                            Norm1
+                            if k == i
+                            else (
+                                Norm2
+                                if k == j
+                                else (
+                                    self.calculateIk(
+                                        Ones, self.kbinedges[0][k], self.kbinedges[1][k]
+                                    )
+                                    if self.low_mem
+                                    else Norms[:, :, :, k]
+                                )
+                            )
+                        )
+                        Ik_Q3 = (
+                            Ik_Q1
+                            if k == i
+                            else (
+                                Ik_Q2
+                                if k == j
+                                else (
+                                    self.calculateIk(
+                                        self.kmesh,
+                                        self.kbinedges[0][k],
+                                        self.kbinedges[1][k],
+                                    )
+                                    if self.low_mem
+                                    else Ik_Qs[:, :, :, k]
+                                )
+                            )
+                        )
 
-                        effectiveKs.append([
-                            jnp.sum(Ik_Q1 * Norm2 * Norm3),
-                            jnp.sum(Norm1 * Ik_Q2 * Norm3),
-                            jnp.sum(Norm1 * Norm2 * Ik_Q3)
-                        ])
+                        effectiveKs.append(
+                            [
+                                jnp.sum(Ik_Q1 * Norm2 * Norm3),
+                                jnp.sum(Norm1 * Ik_Q2 * Norm3),
+                                jnp.sum(Norm1 * Norm2 * Ik_Q3),
+                            ]
+                        )
 
-        elif mode == 'custom':
+        elif mode == "custom":
             if not custom_kbinedges_low or not custom_kbinedges_high:
-                raise ValueError(f"custom_kbinedges need to be provided if mode is {mode}")
+                raise ValueError(
+                    f"custom_kbinedges need to be provided if mode is {mode}"
+                )
             if self.low_mem and self.verbose:
-                print("Warning: Using low-memory mode with custom bin edges; high-memory optimization not applicable.")
+                print(
+                    "Warning: Using low-memory mode with custom bin edges; high-memory optimization not applicable."
+                )
             for low, high in zip(custom_kbinedges_low, custom_kbinedges_high):
                 Norm2, Norm3 = [self.calculateIk(Ones, low[i], high[i]) for i in (1, 2)]
                 Ik_Q1 = self.calculateIk(self.kmesh, low[0], high[0])
@@ -256,24 +403,37 @@ class bispectrumExtractor:
                 effectiveKs.append([k1, k2, k3])
 
         else:
-            raise ValueError(f"Mode cannot be {mode}, must be 'all', 'equilateral', or 'custom'.")
+            raise ValueError(
+                f"Mode cannot be {mode}, must be 'all', 'equilateral', or 'custom'."
+            )
 
         return effectiveKs
 
-
-
-
-    def calculateBispectrum(self, field_real, mode='equilateral', custom_kbinedges_low=[], custom_kbinedges_high=[]):
+    def calculateBispectrum(
+        self,
+        field_real,
+        mode="equilateral",
+        custom_kbinedges_low=[],
+        custom_kbinedges_high=[],
+    ):
         """Calculates the unnormalized Bispectrum using either the low-memory or high-memory code.
+
+        If `self.low_mem` is True, the I_ks are calculated on the fly which requires less memory but is slower for unequilateral triangles.
+        Else, the I_ks are calculated once and stored in memory. This should usually be faster, but could run over the RAM.
+        It could also trigger that CPU calculation instead of GPU calculation is performed, which massively decreases the speed.
+
 
         Args:
             field_real (np.ndarray): Real space density field (in numpy binary format).
-            mode (str, optional): Which k-triangles to consider. Can be 'equilateral', 'all', 'custom'. Defaults to 'equilateral'.
+            mode (str, optional): Which k-triangles to consider. Can be 'equilateral', 'custom', or 'all'. Defaults to 'equilateral'.
+            custom_kbinedges_low (list, optional): lower edge of custom k-bins. Defaults to [].
+            custom_kbinedges_high (list, optional): higher edge of custom k-bins. Defaults to [].
+            precision (dtype, optional): float type of calculation. Defaults to np.float64
 
         Returns:
             list: Unnormalized bispectrum for each triangle configuration.
         """
-        
+
         if self.verbose:
             print("Doing Fourier Transformation of density field")
         field_fourier = self.getFourierField(field_real)
@@ -282,270 +442,89 @@ class bispectrumExtractor:
             print("Doing Bispec calculation")
 
         bispec = []
-        Iks = None if self.low_mem else self.calculateIks(field_fourier)  # Precompute all Iks if not low_mem
+        Iks = (
+            None if self.low_mem else self.calculateIks(field_fourier)
+        )  # Precompute all Iks if not low_mem
 
-        if mode in {'equilateral', 'all'}:
+        if mode in {"equilateral", "all"}:
             for i in range(self.Nks):
-                Ik1 = self.calculateIk(field_fourier, self.kbinedges[0][i], self.kbinedges[1][i]) if self.low_mem else Iks[:,:,:,i]
+                Ik1 = (
+                    self.calculateIk(
+                        field_fourier, self.kbinedges[0][i], self.kbinedges[1][i]
+                    )
+                    if self.low_mem
+                    else Iks[:, :, :, i]
+                )
 
-                if mode == 'equilateral':
+                if mode == "equilateral":
                     bispec.append(jnp.sum(Ik1**3))
                     continue
 
                 for j in range(i, self.Nks):
-                    Ik2 = Ik1 if i == j else (self.calculateIk(field_fourier, self.kbinedges[0][j], self.kbinedges[1][j]) if self.low_mem else Iks[:,:,:,j])
+                    Ik2 = (
+                        Ik1
+                        if i == j
+                        else (
+                            self.calculateIk(
+                                field_fourier,
+                                self.kbinedges[0][j],
+                                self.kbinedges[1][j],
+                            )
+                            if self.low_mem
+                            else Iks[:, :, :, j]
+                        )
+                    )
 
                     for k in range(j, self.Nks):
-                        if self.kbinedges[2][k] > self.kbinedges[2][i] + self.kbinedges[2][j]:
+                        if (
+                            self.kbinedges[2][k]
+                            > self.kbinedges[2][i] + self.kbinedges[2][j]
+                        ):
                             continue
 
-                        Ik3 = Ik1 if k == i else (Ik2 if k == j else (self.calculateIk(field_fourier, self.kbinedges[0][k], self.kbinedges[1][k]) if self.low_mem else Iks[:,:,:,k]))
+                        Ik3 = (
+                            Ik1
+                            if k == i
+                            else (
+                                Ik2
+                                if k == j
+                                else (
+                                    self.calculateIk(
+                                        field_fourier,
+                                        self.kbinedges[0][k],
+                                        self.kbinedges[1][k],
+                                    )
+                                    if self.low_mem
+                                    else Iks[:, :, :, k]
+                                )
+                            )
+                        )
 
                         bispec.append(jnp.sum(Ik1 * Ik2 * Ik3))
 
-        elif mode == 'custom':
+        elif mode == "custom":
             if not custom_kbinedges_low or not custom_kbinedges_high:
-                raise ValueError(f"custom_kbinedges need to be provided if mode is {mode}")
+                raise ValueError(
+                    f"custom_kbinedges need to be provided if mode is {mode}"
+                )
 
             if self.low_mem and self.verbose:
-                print("Warning: Using low-memory mode with custom bin edges; high-memory optimization not applicable.")
+                print(
+                    "Warning: Using low-memory mode with custom bin edges; high-memory optimization not applicable."
+                )
 
             for low, high in zip(custom_kbinedges_low, custom_kbinedges_high):
-                Ik1, Ik2, Ik3 = [self.calculateIk(field_fourier, low[i], high[i]) for i in range(3)]
+                Ik1, Ik2, Ik3 = [
+                    self.calculateIk(field_fourier, low[i], high[i]) for i in range(3)
+                ]
                 bispec.append(jnp.sum(Ik1 * Ik2 * Ik3))
 
         else:
-            raise ValueError(f"Mode cannot be {mode}, must be either 'all', 'equilateral', or 'custom'.")
+            raise ValueError(
+                f"Mode cannot be {mode}, must be either 'all', 'equilateral', or 'custom'."
+            )
 
         return bispec
-
-        
-
-    # def calculateBispectrum_slow(self, field_real, mode='equilateral', custom_kbinedges_low=[], custom_kbinedges_high=[]):
-    #     """Calculates the unnormalized Bispectrum with the slower (but less memory intensive) algortihm
-
-    #     Args:
-    #         field_real (np.ndarray): Real space density field (in numpy binary format)
-    #         mode (str, optional): Which k-triangles to consider. Can be 'equilateral', 'all' or 'custom'. Defaults to 'equilateral'. If 'custom': bin-edges of k need to be provided
-
-
-    #     Warning:
-    #         This algorithm should be the same speed as calculateBispectrum for equilateral triangles, but significantly slower for all triangles!
-
-    #     Returns:
-    #         list: unnormalized bispectrum for each triangle configuration
-    #     """
-
-    #     if self.verbose:
-    #         print("Doing Fourier Transformation of density field")
-
-    #     field_fourier=self.getFourierField(field_real)
-
-    #     if self.verbose:
-    #         print("Doing Bispec calculation")
-    #     bispec=[]
-    #     if mode=='equilateral':
-    #         for i in range(self.Nks):
-    #             Ik=self.calculateIk(field_fourier, self.kbinedges[0][i], self.kbinedges[1][i])
-    #             tmp=jnp.sum(Ik**3)
-    #             bispec.append(tmp)
-    #     elif mode=='all':
-    #         for i in range(self.Nks):
-    #             Ik1=self.calculateIk(field_fourier, self.kbinedges[0][i], self.kbinedges[1][i])
-    #             for j in range(i, self.Nks):
-    #                 if(i==j):
-    #                     Ik2=Ik1
-    #                 else:
-    #                     Ik2=self.calculateIk(field_fourier, self.kbinedges[0][j], self.kbinedges[1][j])
-    #                 for k in range(j, self.Nks):
-    #                     if self.kbinedges[2][k]<=self.kbinedges[2][i]+self.kbinedges[2][j]:
-    #                         if (k==i):
-    #                             Ik3=Ik1
-    #                         elif (k==j):
-    #                             Ik3=Ik2
-    #                         else:
-    #                             Ik3=self.calculateIk(field_fourier, self.kbinedges[0][k], self.kbinedges[1][k])
-    #                         tmp=jnp.sum(Ik1*Ik2*Ik3)
-    #                         del Ik3
-    #                         bispec.append(tmp)
-    #     elif mode=='custom':
-    #         if (len(custom_kbinedges_low)==0) or (len(custom_kbinedges_high)==0):
-    #             raise ValueError(f"custom_kbinedges need to be provided if mode is {mode}")
-    #         for i in range(len(custom_kbinedges_low)):
-    #             Ik1=self.calculateIk(field_fourier, custom_kbinedges_low[i][0], custom_kbinedges_high[i][0])
-    #             Ik2=self.calculateIk(field_fourier, custom_kbinedges_low[i][1], custom_kbinedges_high[i][1])
-    #             Ik3=self.calculateIk(field_fourier, custom_kbinedges_low[i][2], custom_kbinedges_high[i][2])
-
-    #             tmp=jnp.sum(Ik1*Ik2*Ik3)
-    #             del Ik1
-    #             del Ik2
-    #             del Ik3
-
-    #             bispec.append(tmp)
-    #     else:
-    #         raise ValueError(f"Mode cannot be {mode}, has to be either 'all', 'equilateral' or 'custom'")
-        
-    #     return bispec
-    
-
-
-    # def calculateBispectrumNormalization_slow(self, mode='equilateral', custom_kbinedges_low=[], custom_kbinedges_high=[], precision=np.float64):
-    #     """Calculates the normalization with the slower (but less memory intensive) algortihm. Only needs to be run once for all simulations with the same L and Nmesh
-
-    #     Args:
-    #         mode (str, optional): Which k-triangles to consider. Can be 'equilateral', 'all' or 'custom'. Defaults to 'equilateral'. If 'custom': bin-edges of k need to be provided
-
-    #     Warning:
-    #        This algorithm should be the same speed as calculateBispectrumNormalization for equilateral triangles, but significantly slower for all triangles!
-
-    #     Returns:
-    #         list: unnormalized bispectrum for each triangle configuration
-    #     """
-    #     Ones=jnp.ones((self.Nmesh, self.Nmesh, self.Nmesh), dtype=precision)
-
-    #     normalization=[]
-    #     if mode=='equilateral':
-    #         for i in range(self.Nks):
-    #             Norm=self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i])
-    #             tmp=jnp.sum(Norm**3)
-    #             normalization.append(tmp)
-    #     elif mode=='all':
-    #         for i in range(self.Nks):
-    #             Norm1=self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i])
-
-
-    #             for j in range(i, self.Nks):
-    #                 if i==j:
-    #                     Norm2=Norm1
-    #                 else:
-    #                     Norm2=self.calculateIk(Ones, self.kbinedges[0][j], self.kbinedges[1][j])
-
-    #                 for k in range(j, self.Nks):
-    #                     if self.kbinedges[2][k]<=self.kbinedges[2][i]+self.kbinedges[2][j]:
-    #                         if k==i:
-    #                             Norm3=Norm1
-    #                         elif k==j:
-    #                             Norm3=Norm2
-    #                         else:
-    #                             Norm3=self.calculateIk(Ones, self.kbinedges[0][k], self.kbinedges[1][k])
-    #                         tmp=jnp.sum(Norm1*Norm2*Norm3)
-    #                         del Norm3
-    #                         normalization.append(tmp)
-    #                 del Norm2
-    #     elif mode=='custom':
-    #         if (len(custom_kbinedges_low)==0) or (len(custom_kbinedges_high)==0):
-    #             raise ValueError(f"custom_kbinedges need to be provided if mode is {mode}")
-    #         for i in range(len(custom_kbinedges_low)):
-    #             Norm1=self.calculateIk(Ones, custom_kbinedges_low[i][0], custom_kbinedges_high[i][0])
-    #             Norm2=self.calculateIk(Ones, custom_kbinedges_low[i][1], custom_kbinedges_high[i][1])
-    #             Norm3=self.calculateIk(Ones, custom_kbinedges_low[i][2], custom_kbinedges_high[i][2])
-
-    #             tmp=jnp.sum(Norm1*Norm2*Norm3)
-    #             del Norm1
-    #             del Norm2
-    #             del Norm3
-    #             normalization.append(tmp)
-
-
-    #     else:
-    #         raise ValueError(f"Mode cannot be {mode}, has to be either 'all','equilateral' or 'custom'")
-        
-    #     return normalization
-    
-
-    def calculateEffectiveTriangle_slow(self, mode='equilateral', custom_kbinedges_low=[], custom_kbinedges_high=[], precision=np.float64):
-        """Calculates the (unnormalized) Effective Triangles with the slower (but less memory intensive) algortihm. Only needs to be run once for all simulations with the same L and Nmesh
-
-        uses Eq. 3.7 from https://arxiv.org/pdf/1908.01774.pdf
-        
-        Args:
-            mode (str, optional): Which k-triangles to consider. Can be 'equilateral', 'all' or 'custom'. Defaults to 'equilateral'. If 'custom': bin-edges of k need to be provided
-
-        Warning:
-           This algorithm should be the same speed as calculateEffectiveTriangle for equilateral triangles, but significantly slower for all triangles!
-
-        Returns:
-            list: unnormalized bispectrum for each triangle configuration
-        """
-        Ones=jnp.ones((self.Nmesh, self.Nmesh, self.Nmesh), dtype=precision)
-
-        effectiveKs=[]
-
-        if mode=='equilateral':
-            for i in range(self.Nks):
-                Norm=self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i])
-                Ik_Q=self.calculateIk(self.kmesh, self.kbinedges[0][i], self.kbinedges[1][i])
-                k=jnp.sum(Norm**2*Ik_Q)
-                effectiveKs.append([k,k,k])
-        elif mode=='all':
-            for i in range(self.Nks):
-                Norm1=self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i])
-
-                Ik_Q1=self.calculateIk(self.kmesh, self.kbinedges[0][i], self.kbinedges[1][i])
-
-                for j in range(i, self.Nks):
-                    if i==j:
-                        Norm2=Norm1
-                        Ik_Q2=Ik_Q1
-                    else:
-                        Norm2=self.calculateIk(Ones, self.kbinedges[0][j], self.kbinedges[1][j])
-                        Ik_Q2=self.calculateIk(self.kmesh, self.kbinedges[0][j], self.kbinedges[1][j])
-
-
-                    for k in range(j, self.Nks):
-                        if self.kbinedges[2][k]<=self.kbinedges[2][i]+self.kbinedges[2][j]:
-                            if k==i:
-                                Norm3=Norm1
-                                Ik_Q3=Ik_Q1
-                            elif k==j:
-                                Norm3=Norm2
-                                Ik_Q3=Ik_Q2
-                            else:
-                                Norm3=self.calculateIk(Ones, self.kbinedges[0][k], self.kbinedges[1][k])
-                                Ik_Q3=self.calculateIk(self.kmesh, self.kbinedges[0][k], self.kbinedges[1][k])
-
-                            k1=jnp.sum(Ik_Q1*Norm2*Norm3)
-                            k2=jnp.sum(Norm1*Ik_Q2*Norm3)
-                            k3=jnp.sum(Norm1*Norm2*Ik_Q3)
-                            del Norm3
-                            del Ik_Q3
-                            effectiveKs.append([k1,k2,k3])
-
-                    del Norm2
-                    del Ik_Q2
-        elif mode=='custom':
-            if (len(custom_kbinedges_low)==0) or (len(custom_kbinedges_high)==0):
-                raise ValueError(f"custom_kbinedges need to be provided if mode is {mode}")
-            for i in range(len(custom_kbinedges_low)):
-                Norm2=self.calculateIk(Ones, custom_kbinedges_low[i][1], custom_kbinedges_high[i][1])
-                Norm3=self.calculateIk(Ones, custom_kbinedges_low[i][2], custom_kbinedges_high[i][2])
-
-                Ik_Q1=self.calculateIk(self.kmesh, custom_kbinedges_low[i][0], custom_kbinedges_high[i][0])
-                k1=jnp.sum(Ik_Q1*Norm2*Norm3)
-                del Ik_Q1
-
-                Norm1=self.calculateIk(Ones, custom_kbinedges_low[i][0], custom_kbinedges_high[i][0])
-                Ik_Q2=self.calculateIk(self.kmesh, custom_kbinedges_low[i][1], custom_kbinedges_high[i][1])
-                k2=jnp.sum(Norm1*Ik_Q2*Norm3)
-                del Ik_Q2
-                del Norm3
-
-
-                Ik_Q3=self.calculateIk(self.kmesh, custom_kbinedges_low[i][2], custom_kbinedges_high[i][2])
-                k3=jnp.sum(Norm1*Norm2*Ik_Q3)
-                del Ik_Q3
-
-
-                del Norm1
-                del Norm2
-
-                effectiveKs.append([k1,k2,k3])
-
-        else:
-            raise ValueError(f"Mode cannot be {mode}, has to be either 'all','equilateral' or 'custom'")
-        
-        return effectiveKs
-
 
     def calculatePowerspectrum(self, field_real):
         """Calculates the unnormalized Powerspectrum
@@ -562,32 +541,37 @@ class bispectrumExtractor:
         if self.verbose:
             print("Doing Fourier Transformation of density field")
 
-        field_fourier=self.getFourierField(field_real)
+        field_fourier = self.getFourierField(field_real)
 
         if self.verbose:
             print("Doing Powerspec calculation")
-        powerspec=[]
+        powerspec = []
 
         for i in range(self.Nks):
-            Ik=np.real(self.calculateIk(field_fourier, self.kbinedges[0][i], self.kbinedges[1][i]))
-            tmp=jnp.sum(Ik**2)
+            Ik = np.real(
+                self.calculateIk(
+                    field_fourier, self.kbinedges[0][i], self.kbinedges[1][i]
+                )
+            )
+            tmp = jnp.sum(Ik**2)
             powerspec.append(tmp)
 
         return powerspec
-    
 
     def calculatePowerspectrumNormalization(self, precision=np.float64):
 
-        Ones=jnp.ones((self.Nmesh, self.Nmesh, self.Nmesh), dtype=precision)
-        
+        Ones = jnp.ones((self.Nmesh, self.Nmesh, self.Nmesh), dtype=precision)
+
         if self.verbose:
             print("Doing Powerspec normalization calculation")
 
-        normalization=[]
+        normalization = []
 
         for i in range(self.Nks):
-            Norm=np.real(self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i]))
-            tmp=jnp.sum(Norm**2)
+            Norm = np.real(
+                self.calculateIk(Ones, self.kbinedges[0][i], self.kbinedges[1][i])
+            )
+            tmp = jnp.sum(Norm**2)
             normalization.append(tmp)
 
         return normalization

--- a/examples/ExampleRunningBiG.ipynb
+++ b/examples/ExampleRunningBiG.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,39 +13,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Processing /home/laila/CodeRepos/BiG\n",
-      "  Preparing metadata (setup.py) ... \u001b[?25ldone\n",
-      "\u001b[?25hRequirement already satisfied: numpy in /home/laila/miniconda3/envs/bihmcode/lib/python3.12/site-packages (from BiG==2.0.0.dev0) (1.26.2)\n",
-      "Collecting argparse (from BiG==2.0.0.dev0)\n",
-      "  Using cached argparse-1.4.0-py2.py3-none-any.whl.metadata (2.8 kB)\n",
-      "Requirement already satisfied: pathlib in /home/laila/miniconda3/envs/bihmcode/lib/python3.12/site-packages (from BiG==2.0.0.dev0) (1.0.1)\n",
-      "Requirement already satisfied: jax in /home/laila/miniconda3/envs/bihmcode/lib/python3.12/site-packages (from BiG==2.0.0.dev0) (0.4.23)\n",
-      "Requirement already satisfied: ml-dtypes>=0.2.0 in /home/laila/miniconda3/envs/bihmcode/lib/python3.12/site-packages (from jax->BiG==2.0.0.dev0) (0.3.2)\n",
-      "Requirement already satisfied: opt-einsum in /home/laila/miniconda3/envs/bihmcode/lib/python3.12/site-packages (from jax->BiG==2.0.0.dev0) (3.3.0)\n",
-      "Requirement already satisfied: scipy>=1.9 in /home/laila/miniconda3/envs/bihmcode/lib/python3.12/site-packages (from jax->BiG==2.0.0.dev0) (1.11.4)\n",
-      "Using cached argparse-1.4.0-py2.py3-none-any.whl (23 kB)\n",
-      "Building wheels for collected packages: BiG\n",
-      "  Building wheel for BiG (setup.py) ... \u001b[?25ldone\n",
-      "\u001b[?25h  Created wheel for BiG: filename=BiG-2.0.0.dev0-py3-none-any.whl size=21315 sha256=535c9aa97f3308f389f4167b36c0f90ff0111cc858df29048d7dd803974c6e2d\n",
-      "  Stored in directory: /tmp/pip-ephem-wheel-cache-ajjvcg2x/wheels/c1/87/94/f083324098ffff65a492b316de576fcd4676425a2b9e52c662\n",
-      "Successfully built BiG\n",
-      "Installing collected packages: argparse, BiG\n",
-      "  Attempting uninstall: BiG\n",
-      "    Found existing installation: BiG 0.1.3\n",
-      "    Uninstalling BiG-0.1.3:\n",
-      "      Successfully uninstalled BiG-0.1.3\n",
-      "Successfully installed BiG-2.0.0.dev0 argparse-1.4.0\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# pip install ../"
    ]
@@ -83,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -104,19 +74,19 @@
       "Creating k-mesh\n",
       "Finished initialization BispectrumExtractor\n",
       "Finished calculating bispectrum norm\n",
-      "Needed 9.760926246643066 seconds to run\n",
+      "Needed 9.73603343963623 seconds to run\n",
       "Calculating bispectrum for /home/laila/CodeRepos/BiG/examples/test_grid_512_1.npy\n",
       "\n",
       "Doing Fourier Transformation of density field\n",
       "Doing Bispec calculation\n",
       "Finished bispectrum calculation\n",
-      "Needed 9.572518587112427 seconds to run\n",
+      "Needed 9.55878496170044 seconds to run\n",
       "Written output to ../examples/testRun_outputtest_grid_512_1.dat\n",
       "Calculating bispectrum for /home/laila/CodeRepos/BiG/examples/test_grid_512_2.npy\n",
       "Doing Fourier Transformation of density field\n",
       "Doing Bispec calculation\n",
       "Finished bispectrum calculation\n",
-      "Needed 2.634753465652466 seconds to run\n",
+      "Needed 2.458399772644043 seconds to run\n",
       "Written output to ../examples/testRun_outputtest_grid_512_2.dat\n"
      ]
     }
@@ -143,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -226,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {

--- a/examples/ExampleRunningBiG.ipynb
+++ b/examples/ExampleRunningBiG.ipynb
@@ -12,6 +12,45 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Processing /home/laila/CodeRepos/BiG\n",
+      "  Preparing metadata (setup.py) ... \u001b[?25ldone\n",
+      "\u001b[?25hRequirement already satisfied: numpy in /home/laila/miniconda3/envs/bihmcode/lib/python3.12/site-packages (from BiG==2.0.0.dev0) (1.26.2)\n",
+      "Collecting argparse (from BiG==2.0.0.dev0)\n",
+      "  Using cached argparse-1.4.0-py2.py3-none-any.whl.metadata (2.8 kB)\n",
+      "Requirement already satisfied: pathlib in /home/laila/miniconda3/envs/bihmcode/lib/python3.12/site-packages (from BiG==2.0.0.dev0) (1.0.1)\n",
+      "Requirement already satisfied: jax in /home/laila/miniconda3/envs/bihmcode/lib/python3.12/site-packages (from BiG==2.0.0.dev0) (0.4.23)\n",
+      "Requirement already satisfied: ml-dtypes>=0.2.0 in /home/laila/miniconda3/envs/bihmcode/lib/python3.12/site-packages (from jax->BiG==2.0.0.dev0) (0.3.2)\n",
+      "Requirement already satisfied: opt-einsum in /home/laila/miniconda3/envs/bihmcode/lib/python3.12/site-packages (from jax->BiG==2.0.0.dev0) (3.3.0)\n",
+      "Requirement already satisfied: scipy>=1.9 in /home/laila/miniconda3/envs/bihmcode/lib/python3.12/site-packages (from jax->BiG==2.0.0.dev0) (1.11.4)\n",
+      "Using cached argparse-1.4.0-py2.py3-none-any.whl (23 kB)\n",
+      "Building wheels for collected packages: BiG\n",
+      "  Building wheel for BiG (setup.py) ... \u001b[?25ldone\n",
+      "\u001b[?25h  Created wheel for BiG: filename=BiG-2.0.0.dev0-py3-none-any.whl size=21315 sha256=535c9aa97f3308f389f4167b36c0f90ff0111cc858df29048d7dd803974c6e2d\n",
+      "  Stored in directory: /tmp/pip-ephem-wheel-cache-ajjvcg2x/wheels/c1/87/94/f083324098ffff65a492b316de576fcd4676425a2b9e52c662\n",
+      "Successfully built BiG\n",
+      "Installing collected packages: argparse, BiG\n",
+      "  Attempting uninstall: BiG\n",
+      "    Found existing installation: BiG 0.1.3\n",
+      "    Uninstalling BiG-0.1.3:\n",
+      "      Successfully uninstalled BiG-0.1.3\n",
+      "Successfully installed BiG-2.0.0.dev0 argparse-1.4.0\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# pip install ../"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/scripts/runBispectrumExtractor.py
+++ b/scripts/runBispectrumExtractor.py
@@ -93,7 +93,7 @@ if args.doTiming:
 
 # NORM CALCULATION
 
-norm=Xtract.calculateBispectrumNormalization_slow(mode=mode, precision=np.float32)
+norm=Xtract.calculateBispectrumNormalization(mode=mode, precision=np.float32)
 
 if args.doTiming:
     time2=time.time()
@@ -106,7 +106,7 @@ if args.verbose:
 
 # EFFECTIVE TRIANGLE CALCULATION
 if args.effectiveTriangles:
-    effTriangles=Xtract.calculateEffectiveTriangle_slow(mode=mode)
+    effTriangles=Xtract.calculateEffectiveTriangle(mode=mode)
 
     if args.doTiming:
         time2=time.time()
@@ -126,7 +126,7 @@ for f in filenames:
     
     field_real=loader.load(f.strip())
 
-    bispec=Xtract.calculateBispectrum_slow(field_real, mode=mode)
+    bispec=Xtract.calculateBispectrum(field_real, mode=mode)
 
 
     if args.doTiming:


### PR DESCRIPTION
There is now the option `low_mem` to `bispectrumExtractor` to select whether one wants to use the memory-intensive (but usually faster) method for calculating the bispectrum or the less memory-intensive calculations. The default is `low_mem=True`. 

The faster method is what was previously called `calculateBispectrum` and the slower method is the previous `calculateBispectrum_slow`. These two functions are now combined. The same was done for the effective Triangle and normalization calculations.

The interface for the following methods has changed (not backwards compatible).
```
bispectrumExtractor.calculateBispectrumNormalization
bispectrumExtractor.calculateBispectrum
bispectrumExtractor.calculateEffectiveTriangle
```

The following methods have been removed
```
bispectrumExtractor.calculateBispectrumNormalization_slow
bispectrumExtractor.calculateBispectrum_slow
bispectrumExtractor.calculateEffectiveTriangle_slow
```

`bispectrumExtractor.__init__` has changed, but backwards-compatible.
Scripts are adapted to work as before. Notebooks have not changed.