### PR TITLE
14 cross field bispectrum not the same as single field bispectrum when using modeall

### DIFF
--- a/BiG/bispectrumExtractor.py
+++ b/BiG/bispectrumExtractor.py
@@ -390,15 +390,15 @@ class bispectrumExtractor:
                                         else Iks[0][:, :, :, i])
                 if mode == "equilateral":
                     if self.singleField:
-                        Ik2=Ik1
-                        Ik3=Ik1
+                        Ik1=Ik1**3
                     else:
-                        Ik2 = (self.calculateIk(fields_fourier[1], self.kbinedges[0][i], self.kbinedges[1][i]) if self.low_mem 
+                        Ik1 *= (self.calculateIk(fields_fourier[1], self.kbinedges[0][i], self.kbinedges[1][i]) if self.low_mem 
                                         else Iks[1][:, :, :, i])
-                        Ik3 = (self.calculateIk(fields_fourier[2], self.kbinedges[0][i], self.kbinedges[1][i]) if self.low_mem 
+                        
+                        Ik1 *= (self.calculateIk(fields_fourier[2], self.kbinedges[0][i], self.kbinedges[1][i]) if self.low_mem 
                                         else Iks[2][:, :, :, i])
-                    bispec.append(jnp.sum(Ik1*Ik2*Ik3))
-                    del Ik1, Ik2, Ik3
+                    bispec.append(jnp.sum(Ik1))
+                    del Ik1
                     continue
 
                 j_range = range(i, self.Nks) if self.singleField else range(self.Nks)

--- a/scripts/runBispectrumExtractor_crossFields.py
+++ b/scripts/runBispectrumExtractor_crossFields.py
@@ -162,8 +162,8 @@ for f in filenames:
         elif mode=='all':
             ix=0
             for i in range(Nkbins):
-                for j in range(i, Nkbins):
-                    for k in range(j, Nkbins):
+                for j in range(Nkbins):
+                    for k in range(Nkbins):
                         if kbins_mid[k]<=kbins_mid[i]+kbins_mid[j]:
                             if args.effectiveTriangles:
                                 print(kbins_mid[i], kbins_mid[j], kbins_mid[k], effTriangles[ix][0]/norm[ix], effTriangles[ix][1]/norm[ix], effTriangles[ix][2]/norm[ix],  bispec[ix], norm[ix], bispec[ix]/norm[ix]*Xtract.prefactor, file=o)


### PR DESCRIPTION
Fixed issue #14 ! Problem was that the bispectrum for cross fields was calculated for all k combinations, while for the single field only for k1<=k2<=k3. "runBispectrumExtractor_crossFields.py" was not putting out all combinations correctly. This is now fixed.